### PR TITLE
F design2

### DIFF
--- a/front/src/assets/main.css
+++ b/front/src/assets/main.css
@@ -10,12 +10,33 @@ main {
 a,
 .green {
   text-decoration: none;
-  color: hsla(160, 100%, 37%, 1);
+  color: #2653e4;
   transition: 0.4s;
   padding: 3px;
 }
 @media (hover: hover) {
   a:hover {
-    background-color: hsla(160, 100%, 37%, 0.2);
+    background-color: hsla(199, 100%, 37%, 0.2);
   }
+}
+
+.page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 2em;
+  padding-right: 2em;
+}
+
+.loader {
+  border: 6px solid #eee;
+  border-top: 6px solid #338fe5;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  animation: spin 1s linear infinite;
+  margin: 2em auto;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg);}
+  100% { transform: rotate(360deg);}
 }

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -16,7 +16,6 @@
     <nav>
       <template v-if="isOwnerRoute">
         <!-- 管理者ヘッダー -->
-        <router-link to="/owner">トップ</router-link>
         <router-link to="/owner/toys">商品</router-link>
         <router-link to="/owner/categories">カテゴリ/シリーズ</router-link>
            <router-link to="/owner/reserve">電話予約</router-link>
@@ -59,10 +58,12 @@ const isOwnerRoute = computed(() => {
 .header {
   background-color: #338fe5;
   color: rgb(211, 196, 196);
-  padding: 1em;
+  padding: 0em 1em;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 2em;
+  min-height: 36px;
 }
 
 nav a,
@@ -72,6 +73,11 @@ nav button {
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.header img {
+  margin-top: 1em;
+  height: 50px !important;
 }
 
 nav a:hover,

--- a/front/src/layouts/OwnerLayout.vue
+++ b/front/src/layouts/OwnerLayout.vue
@@ -2,7 +2,9 @@
   <div class="layout-root">
     <Header v-if="isLoggedIn" />
     <main class="main-content">
-      <slot />
+      <div class="page-container">
+        <slot />
+      </div>
     </main>
     <Footer v-if="isLoggedIn" />
   </div>
@@ -21,6 +23,12 @@ const isLoggedIn = computed(() => !!localStorage.getItem('token')) // ユーザ�
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+.page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 2em;
+  padding-right: 2em;
 }
 .main-content {
   flex: 1;

--- a/front/src/layouts/UserLayout.vue
+++ b/front/src/layouts/UserLayout.vue
@@ -2,7 +2,9 @@
   <div class="layout-root">
     <Header v-if="isLoggedIn" />
     <main class="main-content">
-      <slot />
+      <div class="page-container">
+        <slot />
+      </div>
     </main>
     <Footer v-if="isLoggedIn" />
   </div>
@@ -20,6 +22,12 @@ const isLoggedIn = computed(() => !!localStorage.getItem('token'))
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+.page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 2em;
+  padding-right: 2em;
 }
 .main-content {
   flex: 1;

--- a/front/src/views/owner/SalesAnalysis.vue
+++ b/front/src/views/owner/SalesAnalysis.vue
@@ -16,7 +16,9 @@
     </div>
 
       <!-- 読み込み -->
-    <div v-if="loading">読み込み中...</div>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
         <!-- 表 -->
     <div v-else>
       <table>

--- a/front/src/views/owner/SalesAnalysis.vue
+++ b/front/src/views/owner/SalesAnalysis.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h2>売上分析</h2>
+    <h1>売上分析</h1>
     <!-- グラフ -->
     <canvas ref="salesChart"></canvas>
       <!-- 切り替えラジオ -->

--- a/front/src/views/owner/categories/CategoryEdit.vue
+++ b/front/src/views/owner/categories/CategoryEdit.vue
@@ -2,7 +2,10 @@
   <div>
     <h2>カテゴリー編集</h2>
 
-    <div v-if="isSubmitting">読み込み中...</div>
+    <div v-if="isSubmitting">
+      <div class="loader"></div>
+      <p>カテゴリー情報を更新中...</p>
+    </div>
 
     <form @submit.prevent="submit" v-else>
       <div>

--- a/front/src/views/owner/categories/CategoryIndex.vue
+++ b/front/src/views/owner/categories/CategoryIndex.vue
@@ -108,8 +108,8 @@ onMounted(() => {
     <h2><router-link to="/owner/series">シリーズ管理はこちら</router-link></h2>
     <h1> カテゴリ一覧画面</h1>
         <div v-if="loading">
-      読み込み中...
-    </div>
+            <div class="loader"></div>
+        </div>
     <div v-else-if="error">
       エラー: {{ error }}
     </div>

--- a/front/src/views/owner/categories/CategoryIndex.vue
+++ b/front/src/views/owner/categories/CategoryIndex.vue
@@ -105,8 +105,12 @@ onMounted(() => {
 
 <template>
  <div>
-    <h2><router-link to="/owner/series">シリーズ管理はこちら</router-link></h2>
-    <h1> カテゴリ一覧画面</h1>
+    <h1>
+      <span class="active-tab">カテゴリ一覧</span>
+      /
+      <RouterLink to="/owner/series">シリーズ一覧</RouterLink>
+    </h1>
+    <router-link to="/owner/categories/create">新規作成</router-link>
         <div v-if="loading">
             <div class="loader"></div>
         </div>
@@ -114,7 +118,6 @@ onMounted(() => {
       エラー: {{ error }}
     </div>
         <div v-else>
-    <router-link to="/owner/categories/create">新規作成</router-link>
     <table>
       <thead>
         <tr>
@@ -143,14 +146,29 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.active-tab {
+  border-bottom: 3px solid #338fe5;
+  font-weight: bold;
+  padding-bottom: 2px;
+}
+
 table {
-  width: 100%;
+  width: 500px;           /* テーブル全体の幅を固定（必要に応じて調整） */
+  max-width: 100%;
+  margin: 2em auto 0 auto;
   border-collapse: collapse;
-} 
+  table-layout: fixed;    /* 列幅を固定 */
+}
 th, td {
   border: 1px solid #ddd;
-  padding: 8px;
+  padding: 6px;
+  text-align: center;
+  word-break: break-all;
 }
+th:nth-child(1), td:nth-child(1) { width: 50px; }   /* ID */
+th:nth-child(2), td:nth-child(2) { width: 200px; }  /* 名前 */
+th:nth-child(3), td:nth-child(3) { width: 80px; }   /* 表示順 */
+th:nth-child(4), td:nth-child(4) { width: 150px; }   /* 操作 */
 
 button {
   background-color: #f44336; /* 赤色 */

--- a/front/src/views/owner/reserve/ReserveCreate.vue
+++ b/front/src/views/owner/reserve/ReserveCreate.vue
@@ -1,40 +1,46 @@
 <template>
   <div>
-    <h2>電話予約管理</h2>
+    <h1>電話予約管理</h1>
 
     <!-- 新規予約フォーム -->
     <form @submit.prevent="submitReserve">
-          <fieldset :disabled="isSubmitting" style="border: none; padding: 0;">
-      <!-- //送信中はフォームを無効化 -->
-      <div>
-        <label>ユーザーID:</label>
-        <input v-model="form.user_id" type="number" min="1"  required />
-      </div>
-      <div>
-        <label>商品ID:</label>
-        <input v-model="form.toy_id" type="number" min="1" required />
-      </div>
-      <div>
-        <label>予約日:</label>
-        <input v-model="form.reserve_date" type="date" required />
-      </div>
-      <div>
-        <label>予約数:</label>
-        <input v-model="form.reserve_num" type="number" min="1" max="20" required />
-      </div>
-      <!-- <button type="submit">予約登録</button> -->
-      <button type="submit" :disabled="isSubmitting">
-        <!-- {{ isEdit ? '予約更新' : '予約登録' }} -->
-       {{ isSubmitting ? '送信中...' : '登録' }}
-      </button>
-      <br />
-          </fieldset>
+      <fieldset :disabled="isSubmitting" style="border: none; padding: 0;">
+        <div class="form-row">
+          <label>ユーザー</label>
+          <input v-model="form.user_id" type="number" min="1" required @change="updateUserName" />
+          <span class="user-name">
+            <template v-if="form.user_id">
+              <template v-if="selectedUserName">{{ selectedUserName }}</template>
+              <template v-else>ユーザーがいません</template>
+            </template>
+          </span>
+        </div>
+        <div class="form-row">
+          <label>商品</label>
+          <input v-model="form.toy_id" type="number" min="1" required @change="updateToyName" />
+          <span v-if="selectedToyName" class="user-name">{{ selectedToyName }}</span>
+        </div>
+        <div class="form-row">
+          <label>予約日</label>
+          <input v-model="form.reserve_date" type="date" required />
+        </div>
+        <div class="form-row">
+          <label>予約数</label>
+          <input v-model="form.reserve_num" type="number" min="1" max="20" required />
+          <button type="submit" :disabled="isSubmitting || loading" class="inline-btn">
+            {{ isSubmitting ? '送信中...' : '登録' }}
+          </button>
+        </div>
+      </fieldset>
     </form>
 
     <hr />
 
-    <!-- 予約一覧表示 -->
-    <table>
+    <!-- ローディング中はローダーを表示 -->
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
+    <table v-else>
       <thead>
         <tr>
           <th>ID</th>
@@ -50,22 +56,19 @@
           <td>{{ reserve.id }}</td>
           <td>{{ reserve.user?.name || reserve.user_id }}</td>
           <td>{{ reserve.toy?.name || reserve.toy_id }}</td>
-          <!-- // isEditがtrueの場合のみinputにする -->
           <td v-if="isEdit === true && reserve_id === reserve.id">
             <input type="date" v-model="reserve.reserve_date" required>
           </td>
-          <td v-else-if="isEdit === false || reserve_id !== reserve.id">{{ reserve.reserve_date }}</td>
-
+          <td v-else>{{ reserve.reserve_date }}</td>
           <td v-if="isEdit === true && reserve_id === reserve.id">
-            <input type="number" v-model="reserve.reserve_num" min="1" max="20" required> 
+            <input type="number" v-model="reserve.reserve_num" min="1" max="20" required>
           </td>
-          <td v-else-if="isEdit === false || reserve_id !== reserve.id">{{ reserve.reserve_num }}</td>
-          
+          <td v-else>{{ reserve.reserve_num }}</td>
           <td>
-            <button @click="editReserve(reserve)">
-                {{ isEdit ? '予約登録' : '予約編集' }}
+            <button @click="editReserve(reserve)" :disabled="isSubmitting || loading">
+              {{ isEdit && reserve_id === reserve.id ? '予約登録' : '予約編集' }}
             </button>
-            <button @click="deleteReserve(reserve.id)">削除</button>
+            <button @click="deleteReserve(reserve.id)" :disabled="isSubmitting || loading">削除</button>
           </td>
         </tr>
       </tbody>
@@ -78,6 +81,10 @@ import { ref, onMounted } from 'vue'
 import { apiClient } from '@/utils/api.js'
 
 const reserves = ref([])
+const users = ref([])
+const toys = ref([])
+const selectedUserName = ref('')
+const selectedToyName = ref('')
 const form = ref({
   user_id: '',
   toy_id: '',
@@ -86,69 +93,75 @@ const form = ref({
 })
 const isEdit = ref(false)
 const editingId = ref(null)
-const isSubmitting = ref(false);
+const isSubmitting = ref(false)
+const loading = ref(false)
 const reserve_id = ref(null)
 
 const fetchReserves = async () => {
-  //   //  if (isSubmitting.value) return; // すでに送信中なら何もしない
-  //isSubmitting.value = true; // 送信開始でボタン無効化
+  loading.value = true
   try {
     const res = await apiClient.get('/owner/reserves')
-      console.log('取得成功:', res.data)
     reserves.value = res.data
   } catch (e) {
-        console.error('予約一覧取得に失敗', e)
     alert('予約一覧の取得に失敗しました')
   } finally {
-    // 送信完了でボタン再有効化
-    isSubmitting.value = false;
+    loading.value = false
+    isSubmitting.value = false
   }
 }
 
 const submitReserve = async () => {
+  isSubmitting.value = true
+  loading.value = true
   try {
-      await apiClient.post('/owner/reserves', form.value)
-      alert('予約を登録しました')
-    
-      await fetchReserves()
-      resetForm()
+    await apiClient.post('/owner/reserves', form.value)
+    await fetchReserves()
+    resetForm()
   } catch (e) {
     alert(e.response?.data?.message || '予約の登録に失敗しました')
+  } finally {
+    isSubmitting.value = false
+    loading.value = false
   }
 }
 
-// const editReserve = (reserve) => {
-//   form.value = {
-//     user_id: reserve.user_id,
-//     toy_id: reserve.toy_id,
-//     reserve_date: reserve.reserve_date,
-//     reserve_num: reserve.reserve_num
-//   }
-//   isEdit.value = true
-//   editingId.value = reserve.id
-// }
-
-
-async function editReserve(reserve){
-  if(isEdit.value === false){
+async function editReserve(reserve) {
+  if (isEdit.value === false) {
     isEdit.value = true
     reserve_id.value = reserve.id
-  }else if(isEdit.value === true){
+  } else if (isEdit.value === true) {
+    isSubmitting.value = true
+    loading.value = true
     form.value.user_id = reserve.user_id
     form.value.toy_id = reserve.toy_id
     form.value.reserve_date = reserve.reserve_date
     form.value.reserve_num = reserve.reserve_num
-
-    console.log(form.value)
-    await apiClient.put(`/owner/reserves/${reserve.id}`, form.value)
-    resetForm()
+    try {
+      await apiClient.put(`/owner/reserves/${reserve.id}`, form.value)
+      await fetchReserves()
+      resetForm()
+    } catch (e) {
+      alert('予約の編集に失敗しました')
+    } finally {
+      isSubmitting.value = false
+      loading.value = false
+    }
   }
 }
 
 const deleteReserve = async (id) => {
   if (confirm('本当に削除しますか？')) {
-    await apiClient.delete(`/owner/reserves/${id}`)
-    await fetchReserves()
+    isSubmitting.value = true
+    loading.value = true
+    try {
+      await apiClient.delete(`/owner/reserves/${id}`)
+      await fetchReserves()
+    } catch (e) {
+      alert('削除に失敗しました')
+    } finally {
+      isSubmitting.value = false
+      loading.value = false
+    }
   }
 }
 
@@ -161,14 +174,53 @@ const resetForm = () => {
   }
   isEdit.value = false
   editingId.value = null
+  selectedUserName.value = ''
+  selectedToyName.value = ''
+}
+
+// ユーザー一覧を取得
+const fetchUsers = async () => {
+  try {
+    const res = await apiClient.get('/owner/users')
+    users.value = res.data
+  } catch (e) {
+    console.error('ユーザー一覧取得に失敗', e)
+  }
+}
+
+// 商品一覧を取得
+const fetchToys = async () => {
+  try {
+    const res = await apiClient.get('/owner/toys')
+    toys.value = res.data
+  } catch (e) {
+    console.error('商品一覧取得に失敗', e)
+  }
+}
+
+// ユーザーID変更時に名前を表示
+function updateUserName() {
+  const user = users.value.find(u => String(u.id) === String(form.value.user_id))
+  selectedUserName.value = user ? user.name : ''
+}
+
+// 商品ID変更時に商品名を表示
+function updateToyName() {
+  const toy = toys.value.find(t => String(t.id) === String(form.value.toy_id))
+  selectedToyName.value = toy ? toy.name : ''
 }
 
 onMounted(() => {
   fetchReserves()
+  fetchUsers()
+  fetchToys()
 })
 </script>
 
 <style scoped>
+h1 {
+  margin-bottom: 0.5em;
+}
 h2 {
   font-size: 1.5rem;
   margin-bottom: 1rem;
@@ -204,5 +256,62 @@ th, td {
 }
 form > div {
   margin: 0.5rem 0;
+}
+.form-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.form-row input[type="number"] {
+  width: 120px; /* 必要に応じて調整 */
+  flex: unset;
+}
+.form-row input[type="date"] {
+  width: 120px; /* 他の入力欄と同じ幅に揃える */
+  flex: unset;
+}
+.form-row label {
+  width: 90px;      /* ラベルの幅を揃える */
+  margin-right: 1em;
+  text-align: right;
+  flex-shrink: 0;
+}
+.form-row input {
+  flex: 1;
+}
+.user-name {
+  margin-left: 0.5em;
+  font-weight: bold;
+}
+.inline-btn {
+  display: inline-block;
+  padding: 0.3rem 0.6rem;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+.form-row .inline-btn {
+  margin-left: 3em;
+  padding: 0.3rem 1.2em;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  height: 32px;
+  line-height: 1;
+}
+td > button {
+  margin-right: 0.5em;
+}
+
+th:nth-child(6), td:nth-child(6) { width: 150px; }
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 </style>

--- a/front/src/views/owner/series/SeriesEdit.vue
+++ b/front/src/views/owner/series/SeriesEdit.vue
@@ -2,7 +2,10 @@
   <div>
     <h2>シリーズ編集</h2>
 
-    <div v-if="isSubmitting">読み込み中...</div>
+    <div v-if="isSubmitting">
+      <div class="loader"></div>
+      <p>シリーズ情報を更新中...</p>
+    </div>
 
     <form @submit.prevent="submit" v-else>
       <div>

--- a/front/src/views/owner/series/SeriesIndex.vue
+++ b/front/src/views/owner/series/SeriesIndex.vue
@@ -105,65 +105,82 @@ onMounted(() => {
 
 <template>
   <div>
-<h2><router-link to="/owner/categories">カテゴリ一管理はこちら</router-link></h2>
-    <h1>シリーズ一覧画面</h1>
-        <div v-if="loading">
-            <div class="loader"></div>
-        </div>
+    <h1>
+      <RouterLink to="/owner/categories">カテゴリ一覧</RouterLink>
+      /
+      <span class="active-tab">シリーズ一覧</span>
+    </h1>
+    <router-link to="/owner/series/create">新規作成</router-link>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
     <div v-else-if="error">
       エラー: {{ error }}
     </div>
-        <div v-else>
-    <router-link to="/owner/series/create">新規作成</router-link>
-    <table>
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>名前</th>
-          <th>表示順</th>
-          <th>操作</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="category in series" :key="category.id">
-          <td>{{ category.id }}</td>
-          <td>{{ category.name }}</td>
-          <td>{{ category.sort_order }}</td>
-          <td>
-            <router-link :to="`/owner/series/${category.id}/edit`">編集</router-link>
-            <span class="space"></span>
-            <button @click="confirmDelete(category.id)">削除</button>
-            <p v-if="message">{{ message }}</p>
-            <p v-if="errorMessage" style="color: red">{{ errorMessage }}</p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>名前</th>
+            <th>表示順</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="category in series" :key="category.id">
+            <td>{{ category.id }}</td>
+            <td>{{ category.name }}</td>
+            <td>{{ category.sort_order }}</td>
+            <td>
+              <router-link :to="`/owner/series/${category.id}/edit`">編集</router-link>
+              <span class="space"></span>
+              <button @click="confirmDelete(category.id)">削除</button>
+              <p v-if="message">{{ message }}</p>
+              <p v-if="errorMessage" style="color: red">{{ errorMessage }}</p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
 
 <style scoped>
-.space{
-margin-left:20px;
+.active-tab {
+  border-bottom: 3px solid #338fe5;
+  font-weight: bold;
+  padding-bottom: 2px;
+}
+.space {
+  margin-left: 20px;
 }
 table {
-  width: 100%;
+  width: 500px;           /* テーブル全体の幅を固定（必要に応じて調整） */
+  max-width: 100%;
+  margin: 2em auto 0 auto;
   border-collapse: collapse;
-} 
+  table-layout: fixed;    /* 列幅を固定 */
+}
 th, td {
   border: 1px solid #ddd;
   padding: 6px;
+  text-align: center;
+  word-break: break-all;
 }
+th:nth-child(1), td:nth-child(1) { width: 50px; }   /* ID */
+th:nth-child(2), td:nth-child(2) { width: 200px; }  /* 名前 */
+th:nth-child(3), td:nth-child(3) { width: 80px; }   /* 表示順 */
+th:nth-child(4), td:nth-child(4) { width: 150px; }   /* 操作 */
 
 button {
-  background-color: #f44336; /* 赤色 */
+  background-color: #f44336;
   color: white;
   border: none;
   padding: 5px 10px;
   cursor: pointer;
 }
 button:hover {
-  background-color: #d32f2f; /* 濃い赤色 */
+  background-color: #d32f2f;
 }
 </style>

--- a/front/src/views/owner/series/SeriesIndex.vue
+++ b/front/src/views/owner/series/SeriesIndex.vue
@@ -108,8 +108,8 @@ onMounted(() => {
 <h2><router-link to="/owner/categories">カテゴリ一管理はこちら</router-link></h2>
     <h1>シリーズ一覧画面</h1>
         <div v-if="loading">
-      読み込み中...
-    </div>
+            <div class="loader"></div>
+        </div>
     <div v-else-if="error">
       エラー: {{ error }}
     </div>

--- a/front/src/views/owner/stock/HistoryIndex.vue
+++ b/front/src/views/owner/stock/HistoryIndex.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <h1><RouterLink :to="`/owner/stocks`">在庫管理</RouterLink> / 在庫履歴</h1>
-    <div v-if="loading">読み込み中...</div>
+      <div v-if="loading">
+          <div class="loader"></div>
+      </div>
     <div v-else-if="error">{{ error }}</div>
     <div v-else>
       <table border="1" style="border-collapse: collapse; width: 100%;">

--- a/front/src/views/owner/stock/HistoryIndex.vue
+++ b/front/src/views/owner/stock/HistoryIndex.vue
@@ -1,11 +1,20 @@
 <template>
   <div>
-    <h1><RouterLink :to="`/owner/stocks`">在庫管理</RouterLink> / 在庫履歴</h1>
-      <div v-if="loading">
-          <div class="loader"></div>
-      </div>
+    <h1>
+      <RouterLink :to="`/owner/stocks`">在庫管理</RouterLink>
+      /
+      <span class="active-tab">在庫履歴</span>
+    </h1>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
     <div v-else-if="error">{{ error }}</div>
     <div v-else>
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
       <table border="1" style="border-collapse: collapse; width: 100%;">
         <thead>
           <tr>
@@ -18,7 +27,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="history in histories" :key="history.id">
+          <tr v-for="history in pagedHistories" :key="history.id">
             <td>{{ history.created_at }}</td>
             <td>{{ history.name }}</td>
             <td>{{ history.be_stored }}</td>
@@ -28,17 +37,32 @@
           </tr>
         </tbody>
       </table>
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { apiClient } from '@/utils/api.js'
 
 const histories = ref([])
 const loading = ref(true)
 const error = ref(null)
+
+// ページネーション用
+const currentPage = ref(1)
+const perPage = 20 // 1ページあたりの表示数
+
+const pagedHistories = computed(() => {
+  const start = (currentPage.value - 1) * perPage
+  return histories.value.slice(start, start + perPage)
+})
+const totalPages = computed(() => Math.ceil(histories.value.length / perPage))
 
 const fetchHistories = async () => {
   try {
@@ -53,7 +77,32 @@ const fetchHistories = async () => {
   }
 }
 
+function goToPage(page) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+  }
+}
+
 onMounted(() => {
   fetchHistories()
 })
 </script>
+
+<style scoped>
+.active-tab {
+  border-bottom: 3px solid #338fe5;
+  font-weight: bold;
+  padding-bottom: 2px;
+}
+table {
+  margin-top: 2em;
+}
+.pagination {
+  margin: 1em 0;
+  text-align: center;
+}
+.pagination button {
+  margin: 0 0.5em;
+  padding: 0.3em 1em;
+}
+</style>

--- a/front/src/views/owner/stock/StockIncrement.vue
+++ b/front/src/views/owner/stock/StockIncrement.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <div v-if="loading">読み込み中...</div>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
     <div v-else-if="error">エラー: {{ error }}</div>
     <div v-else-if="toy">
     <h2>ID:{{ toy.id }} 「{{ toy.name }}」</h2>

--- a/front/src/views/owner/stock/StocksIndex.vue
+++ b/front/src/views/owner/stock/StocksIndex.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <h1>在庫管理 / <RouterLink :to="`/owner/stocks/history`">在庫履歴</RouterLink></h1>
-    <div v-if="loading">読み込み中...</div>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
     <div v-else-if="error">{{ error }}</div>
     <div v-else>
       <table border="1" style="border-collapse: collapse; width: 100%;">

--- a/front/src/views/owner/stock/StocksIndex.vue
+++ b/front/src/views/owner/stock/StocksIndex.vue
@@ -1,12 +1,21 @@
 <template>
   <div>
-    <h1>在庫管理 / <RouterLink :to="`/owner/stocks/history`">在庫履歴</RouterLink></h1>
+    <h1>
+      <span class="active-tab">在庫管理</span>
+      /
+      <RouterLink :to="`/owner/stocks/history`">在庫履歴</RouterLink>
+    </h1>
     <div v-if="loading">
       <div class="loader"></div>
     </div>
     <div v-else-if="error">{{ error }}</div>
     <div v-else>
-      <table border="1" style="border-collapse: collapse; width: 100%;">
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
+      <table border="1" style="border-collapse: collapse;">
         <thead>
           <tr>
             <th>おもちゃ名</th>
@@ -14,26 +23,40 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="toy in stocks" :key="toy.id">
+          <tr v-for="toy in pagedStocks" :key="toy.id">
             <td>
-            <RouterLink :to="`/owner/stocks/${toy.id}`">{{ toy.name }}</RouterLink>
+              <RouterLink :to="`/owner/stocks/${toy.id}`">{{ toy.name }}</RouterLink>
             </td>
             <td>{{ toy.stock }}</td>
           </tr>
         </tbody>
       </table>
-      <!-- ページ送りUIを削除 -->
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { apiClient } from '@/utils/api.js'
 
 const stocks = ref([])
 const loading = ref(true)
 const error = ref(null)
+
+// ページネーション用
+const currentPage = ref(1)
+const perPage = 20 // 1ページあたりの表示数
+
+const pagedStocks = computed(() => {
+  const start = (currentPage.value - 1) * perPage
+  return stocks.value.slice(start, start + perPage)
+})
+const totalPages = computed(() => Math.ceil(stocks.value.length / perPage))
 
 const fetchStocks = async () => {
   try {
@@ -48,7 +71,49 @@ const fetchStocks = async () => {
   }
 }
 
+function goToPage(page) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+  }
+}
+
 onMounted(() => {
   fetchStocks()
 })
 </script>
+
+<style scoped>
+.active-tab {
+  border-bottom: 3px solid #338fe5;
+  font-weight: bold;
+  padding-bottom: 2px;
+}
+table {
+  margin-top: 2em;
+  width: 500px;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  border-collapse: collapse;
+  table-layout: fixed; /* 列幅を固定 */
+}
+th, td {
+  padding: 8px;
+  border: 1px solid #ccc;
+}
+th:nth-child(1), td:nth-child(1) {
+  width: 350px; /* おもちゃ名の列幅 */
+}
+th:nth-child(2), td:nth-child(2) {
+  width: 150px; /* 在庫数の列幅 */
+  text-align: right;
+}
+.pagination {
+  margin: 1em 0;
+  text-align: center;
+}
+.pagination button {
+  margin: 0 0.5em;
+  padding: 0.3em 1em;
+}
+</style>

--- a/front/src/views/owner/toys/ToysCreate.vue
+++ b/front/src/views/owner/toys/ToysCreate.vue
@@ -112,7 +112,7 @@
 <template>
     <div>
         <div v-if="loading">
-            カテゴリデータ、シリーズデータを取得中...
+        <div class="loader"></div>
         </div>
 
         <div v-else-if="loadingStore">

--- a/front/src/views/owner/toys/ToysIndex.vue
+++ b/front/src/views/owner/toys/ToysIndex.vue
@@ -59,8 +59,8 @@ onMounted(() => getToys())
 </script>
 
 <template>
+  <h1>登録済み商品一覧</h1>
   <div class="page-container">
-    <h1>登録済み商品一覧</h1>
     <div v-if="loading">
       <div class="loader"></div>
     </div>

--- a/front/src/views/owner/toys/ToysIndex.vue
+++ b/front/src/views/owner/toys/ToysIndex.vue
@@ -1,126 +1,144 @@
 <script setup>
-    import {ref, onMounted} from 'vue'
-    import { apiClient } from '@/utils/api'
-    import { useRouter } from 'vue-router' 
+import { ref, computed, onMounted } from 'vue'
+import { apiClient } from '@/utils/api'
+import { useRouter } from 'vue-router'
 
-    const loading = ref(true)
-    const error = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const toys = ref([])
+const sort = ref(null)
 
-    const toys = ref([])
-    const sort = ref(null)
+// ページネーション用
+const currentPage = ref(1)
+const perPage = 20 // 1ページあたりの表示数
 
-    async function getToys(){
-        try{
-            loading.value = true
-            error.value = null
+const pagedToys = computed(() => {
+  const start = (currentPage.value - 1) * perPage
+  return toys.value.slice(start, start + perPage)
+})
+const totalPages = computed(() => Math.ceil(toys.value.length / perPage))
 
-            const response = await apiClient.get('/owner/toys')
-            toys.value = response.data
-        }catch(err){
-            console.log('商品情報の取得に失敗:', err)
-            error.value = '商品情報の取得に失敗しました'
-        }finally{
-            loading.value = false
-        }
-    }
+async function getToys() {
+  try {
+    loading.value = true
+    error.value = null
+    const response = await apiClient.get('/owner/toys')
+    toys.value = response.data
+    currentPage.value = 1 // 取得時に1ページ目に戻す
+  } catch (err) {
+    console.log('商品情報の取得に失敗:', err)
+    error.value = '商品情報の取得に失敗しました'
+  } finally {
+    loading.value = false
+  }
+}
 
-    async function sortDo(sort){
-        try{
-            loading.value = true
-            error.value = null
+async function sortDo(sort) {
+  try {
+    loading.value = true
+    error.value = null
+    const postData = { sort }
+    const response = await apiClient.post('/owner/toys/sort', postData)
+    toys.value = response.data
+    currentPage.value = 1 // ソート時も1ページ目に戻す
+  } catch (err) {
+    console.log('商品情報の取得に失敗:', err)
+    error.value = '商品情報の取得に失敗しました'
+  } finally {
+    loading.value = false
+  }
+}
 
-            const postData = {'sort' : sort}
-            console.log(postData)
+function goToPage(page) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+  }
+}
 
-            const response = await apiClient.post('/owner/toys/sort', postData)
-            toys.value = response.data
-            console.log(response)
-        }catch(err){
-            console.log('商品情報の取得に失敗:', err)
-            error.value = '商品情報の取得に失敗しました'
-        }finally{
-            loading.value = false
-        }
-    }
-
-    onMounted(() => 
-        getToys() 
-    )
+onMounted(() => getToys())
 </script>
 
 <template>
-    <div class="page-container">
-        <h1>登録済み商品一覧</h1>
-        <div v-if="loading">
-            商品情報を読み取り中...
-        </div>
-
-        <div v-else-if="error">
-            エラー：{{ error }}
-        </div>
-
-        <div v-else>
-            <RouterLink :to="'/owner/toys/create'">商品を新規登録</RouterLink>
-            <div>
-                <h4>ソート:</h4>
-                <select v-model="sort">
-                    <option value="price_high">値段の高い順</option>
-                    <option value="price_low">値段の低い順</option>
-                    <option value="stock_much">在庫多い順</option>
-                    <option value="stock_little">在庫少ない順</option>
-                </select>
-                <input type="button" @click="sortDo(sort)" value="ソートを実行">
-            </div>
-            <table border="1">
-                <tr class="culm_name">
-                    <td>商品名</td>
-                    <td>値段</td>
-                    <td>カテゴリ名</td>
-                    <td>シリーズ名</td>
-                    <td>在庫</td>
-                    <td>販売状況</td>
-                    <td>予約可否</td>
-                </tr>
-                <tr v-for="toy in toys" :key="toy.id">
-                    <td><RouterLink :to="`/owner/toys/${toy.id}`">
-                        {{ toy.name }}
-                    </RouterLink></td>
-                    <td>{{ toy.price }}</td>
-                    <td>{{ toy.category }}</td>
-                    <td>{{ toy.series }}</td>
-                    <td>{{ toy.stock }}</td>
-                    <td>{{ toy.is_selling }}</td>
-                    <td>{{ toy.is_reserve }}</td>
-                </tr>
-            </table>
-        </div>
+  <div class="page-container">
+    <h1>登録済み商品一覧</h1>
+    <div v-if="loading">
+      <div class="loader"></div>
     </div>
+    <div v-else-if="error">
+      エラー：{{ error }}
+    </div>
+    <div v-else>
+      <RouterLink :to="'/owner/toys/create'">商品を新規登録</RouterLink>
+        <div class="sort-row">
+        <label for="sort-select">ソート:</label>
+        <select id="sort-select" v-model="sort">
+            <option value="price_high">値段の高い順</option>
+            <option value="price_low">値段の低い順</option>
+            <option value="stock_much">在庫多い順</option>
+            <option value="stock_little">在庫少ない順</option>
+        </select>
+        <input type="button" @click="sortDo(sort)" value="ソートを実行">
+        </div>
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
+      <table border="1">
+        <tr class="culm_name">
+          <td>商品名</td>
+          <td>値段</td>
+          <td>カテゴリ名</td>
+          <td>シリーズ名</td>
+          <td>在庫</td>
+          <td>販売状況</td>
+          <td>予約可否</td>
+        </tr>
+        <tr v-for="toy in pagedToys" :key="toy.id">
+          <td>
+            <RouterLink :to="`/owner/toys/${toy.id}`">
+              {{ toy.name }}
+            </RouterLink>
+          </td>
+          <td>{{ toy.price }}</td>
+          <td>{{ toy.category }}</td>
+          <td>{{ toy.series }}</td>
+          <td>{{ toy.stock }}</td>
+          <td>{{ toy.is_selling }}</td>
+          <td>{{ toy.is_reserve }}</td>
+        </tr>
+      </table>
+      <!-- ページネーション -->
+      <div class="pagination">
+        <button @click="goToPage(currentPage - 1)" :disabled="currentPage === 1">前へ</button>
+        <span> {{ currentPage }} / {{ totalPages }} </span>
+        <button @click="goToPage(currentPage + 1)" :disabled="currentPage === totalPages">次へ</button>
+      </div>
+    </div>
+  </div>
 </template>
 
 <style scoped>
-.page-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding-left: 2em;
-  padding-right: 2em;
+.pagination {
+  margin-top: 1em;
+  text-align: center;
 }
-.table-wrapper {
-  width: 100%;
-  overflow-x: auto;
+.pagination button {
+  margin: 0 0.5em;
+  padding: 0.3em 1em;
+}
+.sort-row {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1em;
+}
+.sort-row label {
+  margin-bottom: 0;
 }
 table {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed; /* 追加：列幅を均等に */
-}
-th, td {
-  border: 1px solid #ddd;
-  padding: 8px;
-  word-break: break-all; /* 長い文字列も折り返す */
-}
-body, html, .table-wrapper {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  width: 90%; /* 必要に応じて調整 */
 }
 </style>

--- a/front/src/views/owner/toys/ToysShow.vue
+++ b/front/src/views/owner/toys/ToysShow.vue
@@ -53,7 +53,7 @@
     <div>
         <h1>商品詳細</h1>
         <div v-if="loading">
-            商品情報を読み取り中...
+            <div class="loader"></div>
         </div>
 
         <div v-else-if="error">

--- a/front/src/views/owner/toys/ToysShow.vue
+++ b/front/src/views/owner/toys/ToysShow.vue
@@ -50,38 +50,182 @@
 </script>
 
 <template>
-    <div>
-        <h1>商品詳細</h1>
-        <div v-if="loading">
-            <div class="loader"></div>
-        </div>
-
-        <div v-else-if="error">
-            エラー：{{ error }}
-        </div>
-
-        <div v-else>
-            <RouterLink :to="'/owner/toys'">商品一覧へ戻る</RouterLink>
-          <p>商品名: {{ toy.name }}</p>
-          <p>値段: {{ toy.price }}</p>
-          <p>在庫: {{ toy.stock }}</p>
-          <p>商品説明: {{ toy.information }}</p>
-          <p>カテゴリ名: {{ toy.category_name }}</p>
-          <p>カテゴリ人気度: {{ toy.category_pop }}</p>
-          <p>シリーズ名: {{ toy.series_name }}</p>
-          <p>シリーズ人気度: {{ toy.series_pop }}</p>
-          <p>販売状況: {{ toy.is_selling }}</p>
-          <p>予約可否: {{ toy.is_reserve }}</p>
-          <p>発売日:{{ toy.release_date }}</p>
-          <p>
-            <img v-if="toy.image_url" :src="img" alt="toy image" width="200" height="150">
-            <div v-else>
-                登録されている画像はありません
-            </div>
-          </p>
-          <p>
-            <RouterLink :to="`/owner/toys/${toyId}/edit`">商品データ編集</RouterLink>
-          </p>
-        </div>
+  <div class="toy-detail-container">
+    <h1 class="title">商品詳細</h1>
+    <div v-if="loading">
+      <div class="loader"></div>
     </div>
+    <div v-else-if="error">
+      <div class="error-message">エラー：{{ error }}</div>
+    </div>
+    <div v-else>
+      <RouterLink to="/owner/toys" class="back-link">← 商品一覧へ戻る</RouterLink>
+      <div class="toy-detail-flex">
+        <div class="toy-image-area">
+          <img v-if="toy.image_url" :src="img" alt="toy image" class="toy-image" />
+          <div v-else class="no-image">登録されている画像はありません</div>
+        </div>
+        <div class="toy-info">
+          <table class="info-table">
+            <tbody>
+              <tr>
+                <th>商品名</th>
+                <td>{{ toy.name }}</td>
+              </tr>
+              <tr>
+                <th>値段</th>
+                <td>¥{{ toy.price }}</td>
+              </tr>
+              <tr>
+                <th>在庫</th>
+                <td>{{ toy.stock }}</td>
+              </tr>
+              <tr>
+                <th>商品説明</th>
+                <td>{{ toy.information }}</td>
+              </tr>
+              <tr>
+                <th>カテゴリ名</th>
+                <td>{{ toy.category_name }}</td>
+              </tr>
+              <tr>
+                <th>カテゴリ人気度</th>
+                <td>{{ toy.category_pop }}</td>
+              </tr>
+              <tr>
+                <th>シリーズ名</th>
+                <td>{{ toy.series_name }}</td>
+              </tr>
+              <tr>
+                <th>シリーズ人気度</th>
+                <td>{{ toy.series_pop }}</td>
+              </tr>
+              <tr>
+                <th>販売状況</th>
+                <td>{{ toy.is_selling }}</td>
+              </tr>
+              <tr>
+                <th>予約可否</th>
+                <td>{{ toy.is_reserve }}</td>
+              </tr>
+              <tr>
+                <th>発売日</th>
+                <td>{{ toy.release_date }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="edit-link-area">
+        <RouterLink :to="`/owner/toys/${toyId}/edit`" class="edit-link">商品データ編集</RouterLink>
+      </div>
+    </div>
+  </div>
 </template>
+
+<style scoped>
+.toy-detail-container {
+  max-width: 700px;
+  margin: 2em auto;
+  padding: 0em 1.5em;
+}
+.title {
+  text-align: center;
+  color: #338fe5;
+  margin-bottom: 1.5em;
+}
+.back-link {
+  display: inline-block;
+  margin-bottom: 1em;
+  color: #338fe5;
+  text-decoration: none;
+}
+.back-link:hover {
+  text-decoration: underline;
+}
+.toy-detail-flex {
+  display: flex;
+  gap: 2em;
+  align-items: flex-start;
+}
+.toy-image-area {
+  flex-shrink: 0;
+}
+.toy-image {
+  width: 150px;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid #e0e7ef;
+  background: #f8fafc;
+}
+.no-image {
+  width: 150px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8fafc;
+  color: #aaa;
+  border: 1px solid #e0e7ef;
+  border-radius: 8px;
+  font-size: 0.95em;
+}
+.toy-info {
+  flex: 1;
+}
+.info-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5em;
+  background: #fafcff;
+}
+.info-table th, .info-table td {
+  border: 1px solid #e0e7ef;
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+.info-table th {
+  background: #eaf4fc;
+  color: #338fe5;
+  width: 30%;
+  font-weight: bold;
+}
+.info-table td {
+  background: #fff;
+}
+.edit-link-area {
+  text-align: right;
+}
+.edit-link {
+  background: #338fe5;
+  color: #fff;
+  padding: 0.5em 1.2em;
+  border-radius: 5px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background 0.2s;
+}
+.edit-link:hover {
+  background: #1c6fc1;
+}
+.error-message {
+  color: #f44336;
+  text-align: center;
+  margin: 1em 0;
+  font-weight: bold;
+}
+.loader {
+  border: 6px solid #eee;
+  border-top: 6px solid #338fe5;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  animation: spin 1s linear infinite;
+  margin: 2em auto;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg);}
+  100% { transform: rotate(360deg);}
+}
+</style>

--- a/front/src/views/owner/users/UserEdit.vue
+++ b/front/src/views/owner/users/UserEdit.vue
@@ -99,7 +99,7 @@
     <div>
         <h1 v-if="user">{{ user.name }}</h1>
         <div v-if="loading">
-            読み込み中...
+        <div class="loader"></div>
         </div>
 
         <div v-else-if="error">

--- a/front/src/views/owner/users/UsersIndex.vue
+++ b/front/src/views/owner/users/UsersIndex.vue
@@ -52,7 +52,7 @@ onMounted(() => {
   <div>
     <main>
       <div v-if="loading">
-        ユーザーデータを取得中...
+        <div class="loader"></div>
       </div>
       <div v-else>
         <h1>ユーザー一覧</h1>

--- a/front/src/views/owner/users/UsersIndex.vue
+++ b/front/src/views/owner/users/UsersIndex.vue
@@ -49,13 +49,13 @@ onMounted(() => {
 </script>
 
 <template>
+<h1>ユーザー一覧</h1>
   <div>
     <main>
       <div v-if="loading">
         <div class="loader"></div>
       </div>
       <div v-else>
-        <h1>ユーザー一覧</h1>
         <table border="1">
           <tr>
             <th>ID</th>

--- a/front/src/views/toyzamas/buy/history/HistoryIndex.vue
+++ b/front/src/views/toyzamas/buy/history/HistoryIndex.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <h1>注文履歴</h1>
-    <div v-if="loading">読み込み中...</div>
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
     <div v-else-if="error">{{ error }}</div>
     <div v-else>
       <div v-if="histories.length">

--- a/front/src/views/toyzamas/cart/CartIndex.vue
+++ b/front/src/views/toyzamas/cart/CartIndex.vue
@@ -2,7 +2,7 @@
   <div>
     <h1>ショッピングカート</h1>
     <div v-if="loading">
-      読み込み中...
+      <div class="loader"></div>
     </div>
     <div v-else-if="error">
       エラー: {{ error }}

--- a/front/src/views/toyzamas/toys/ToysIndex.vue
+++ b/front/src/views/toyzamas/toys/ToysIndex.vue
@@ -1,32 +1,68 @@
+<template>
+  <h1>商品一覧</h1>
+  <div class="toy-list-container">
+    <div v-if="loading">
+      <div class="loader"></div>
+    </div>
+    <div v-else>
+      <div class="toy-grid">
+        <div v-for="toy in toys" :key="toy.id" class="toy-card">
+          <img :src="toy.image_url" alt="商品画像" class="toy-image" />
+          <div class="toy-info">
+            <p><strong>{{ toy.name }}</strong></p>
+            <p>価格: ¥{{ toy.price }}</p>
+            <a :href="`/toyzamas/toys/${toy.id}`" class="details-link">詳細を見る</a>
+          </div>
+        </div>
+        <form @submit.prevent="loadToys" class="sort-form">
+          <label>
+            <input type="radio" name="sort" value=1 v-model="sort"> 予約対象商品一覧
+          </label>
+          <button type="submit">ソート実行</button>
+          <p>
+            カテゴリ名：
+            <select v-model="category_id">
+              <option v-for="category in categories" :value="category.id">
+                {{ category.name }}
+              </option>
+            </select>
+          </p>
+          <p>
+            シリーズ名：
+            <select v-model="series_id">
+              <option v-for="a_series in series" :value="a_series.id">
+                {{ a_series.name }}
+              </option>
+            </select>
+          </p>
+        </form>
+        <p><a href="/toyzamas/toys">ソートリセット</a></p>
+      </div>
+    </div>
+  </div>
+</template>
+
 <script setup>
 import { ref, onMounted } from 'vue'
 import { apiClient } from '@/utils/api.js'
 
-const toys = ref([]) // toysをリアクティブに定義
-const sort = ref(0);
-
+const toys = ref([])
+const sort = ref(0)
 const categories = ref([])
 const category_id = ref(0)
 const series = ref([])
 const series_id = ref(0)
+const loading = ref(false) // 追加
 
-
-// 商品一覧を取得する関数
 const loadToys = async () => {
-  console.log(category_id.value)
-  console.log(series_id.value)
+  loading.value = true // 追加
   try {
-    // const toyData = {
-    //   category_id: category_id.value,
-    //   series_id: series_id.value,
-    // }
-    const response = await apiClient.get(`/toyzamas/toys?sort=${sort.value}&category_id=${category_id.value}&series_id=${series_id.value}`); // Laravel APIからデータ取得
-    toys.value = response.data; // toysにデータを格納
-    console.log("レスポンス内容:", response);
-    console.log("データ部分:", response.data);
-    console.log("toys部分:", toys.value);
+    const response = await apiClient.get(`/toyzamas/toys?sort=${sort.value}&category_id=${category_id.value}&series_id=${series_id.value}`)
+    toys.value = response.data
   } catch (error) {
-    console.error("データの取得に失敗:", error);
+    console.error("データの取得に失敗:", error)
+  } finally {
+    loading.value = false // 追加
   }
 }
 
@@ -39,63 +75,21 @@ async function getCategories(){
   }
 }
 
-  async function getSeries(){
-    try{
-      const response_series = await apiClient.get('/owner/series')
-      series.value = response_series.data
-      }catch(err){
-          console.log('シリーズ名の取得に失敗:', err)
-      }
+async function getSeries(){
+  try{
+    const response_series = await apiClient.get('/owner/series')
+    series.value = response_series.data
+  }catch(err){
+    console.log('シリーズ名の取得に失敗:', err)
+  }
 }
 
-
-// コンポーネントのマウント時にデータをロード
 onMounted(() => {
-  loadToys();
-  getCategories();
-  getSeries();
+  loadToys()
+  getCategories()
+  getSeries()
 })
 </script>
-
-<template>
-  <div class="toy-list-container">
-  <h1 class="text-2xl font-bold mb-4">商品一覧</h1>
-    <div class="toy-grid">
-      <div v-for="toy in toys" :key="toy.id" class="toy-card">
-        <img :src="toy.image_url" alt="商品画像" class="toy-image" />
-        <div class="toy-info">
-          <p><strong>{{ toy.name }}</strong></p>
-          <p>価格: ¥{{ toy.price }}</p>
-          <a :href="`/toyzamas/toys/${toy.id}`" class="details-link">詳細を見る</a>
-        </div>
-      </div>
-      <form @submit.prevent="loadToys" class="sort-form">
-        <label>
-          <input type="radio" name="sort" value=1 v-model="sort"> 予約対象商品一覧
-        </label>
-        <!-- <p>現在のソート値: {{ sort }}</p> -->
-        <button type="submit">ソート実行</button>
-        <p>
-          カテゴリ名：
-          <select v-model="category_id">
-            <option v-for="category in categories" :value="category.id">
-              {{ category.name }}
-            </option>
-          </select>
-        </p>
-        <p>
-          シリーズ名：
-          <select v-model="series_id">
-            <option v-for="a_series in series" :value="a_series.id">
-              {{ a_series.name }}
-            </option>
-          </select>
-        </p>
-      </form>
-      <p><a href="/toyzamas/toys">ソートリセット</a></p>
-    </div>
-  </div>
-</template>
 
 <style scoped>
 .toy-list-container {

--- a/front/src/views/toyzamas/toys/ToysShow.vue
+++ b/front/src/views/toyzamas/toys/ToysShow.vue
@@ -170,7 +170,7 @@
         </div>
         <h1 v-if="toy">{{ toy.name }}</h1>
         <div v-if="loading">
-            読み込み中...
+        <div class="loader"></div>
         </div>
 
         <div v-else-if="error">


### PR DESCRIPTION
- 全ページの左右に余白を追加
- ヘッダー下に余白を追加
- ページ、内容をロード中にアニメーションが出るように変更

> 登録済み商品一覧

- ページ分け機能実装
- ソートを実行ボタンをソート選択の隣に設置

> 商品詳細
- CSSで全体の装飾
- 登録されている画像がない際の表示を追加

> カテゴリー/シリーズ
- どちらのページにいるかわかりやすくするために下線太字を追加
- ロード中にも新規作成の文字が出るように変更
- テーブルサイズを内容に見合ったサイズに変更

> 電話予約
- 入力画面の長さを統一
- ユーザーと商品を選択した際に名前を出すように変更
- 予約一覧の操作カラムが長かった問題を修正

> 在庫管理/在庫履歴
- ページ分け機能実装
- テーブルサイズを内容に見合ったサイズに変更

> ユーザー管理
- ロード中に「ユーザー一覧」の文字が見えるように修正